### PR TITLE
Added: support for newer settings.xml files when loading default settings

### DIFF
--- a/xbmcaddon.py
+++ b/xbmcaddon.py
@@ -228,7 +228,6 @@ class Addon(KodiStub):
             self.__version = re.findall(r'version="(\d+.\d+.\d+[^"]*)', xml_content)[0]
             self.__add_on_id = re.findall(r'addon\W+id="([^"]+)"', xml_content)[0]
             self.__name = re.findall(r'name="([^"]+)"', xml_content)[0]
-        return
 
     def __get_settings(self):
         if self.__add_on_id in Addon.__settings:
@@ -247,6 +246,8 @@ class Addon(KodiStub):
 
         setting_regex = r'id="([^"]+)"[^>]*default="([^"]*)"'
         results = re.findall(setting_regex, default_xml)
+        if not results:
+            results = re.findall(r'setting id="(.*?)".*?<default>(.*?)<', default_xml, re.DOTALL)
         settings = {}
         for result in results:
             settings[result[0]] = result[1]


### PR DESCRIPTION
### Functional description
<!--- Give a clear explanation of the change, fix or new feature 
that this PR contains -->
<!--- Put your text below this line -->
Addes support for different older style of settngs.xml used by inputstream,adaptive addon 
<!--- Put your text above this line -->

### Reasoning
<!--- Provide a decent justification for this PR -->
<!--- Put your text below this line -->
The mock was not wokring when the code hit the inputstream.adaptive addon. 
<!--- Put your text above this line -->

### Technical description
<!--- Please provide a technical analysis of this PR, explaining the 
 changes that were made. -->
<!--- Put your text below this line -->
When there are no results added a new regex to try and find the older style settings. 
<!--- Put your text above this line -->
