### PR TITLE
implement most of missing id of xbmcaddon.getAddonInfo

### DIFF
--- a/xbmcaddon.py
+++ b/xbmcaddon.py
@@ -245,7 +245,7 @@ class Addon(KodiStub):
         return translations
 
     def __filter_lang_xmltag(self, tag, xml_content):
-        tag_matches = re.findall(r'<' + tag + r'(?:\s*lang=\"([a-zA-Z-]+)\")?\s*>(.*?)</' + tag + '>', xml_content, flags=re.DOTALL)
+        tag_matches = re.findall(r'<' + tag + r'(?:\s*lang=\"([a-zA-Z-_]+)\")?\s*>(.*?)</' + tag + '>', xml_content, flags=re.DOTALL)
         if tag_matches:
             for match in tag_matches:
                 if match[0].startswith('en'):
@@ -259,8 +259,8 @@ class Addon(KodiStub):
 
         with io.open(add_on_xml, encoding='utf-8') as fp:
             xml_content = fp.read()
-            self.__version = re.findall(r'<addon.*?version="(\d+(?:\.\d)?(?:\.\d)?[^"]*)', xml_content, flags=re.DOTALL)[0]
-            self.__add_on_id = re.findall(r'addon\W+id="([^"]+)"', xml_content)[0]
+            self.__version = re.findall(r'<addon.*?version="([^"]*)', xml_content, flags=re.DOTALL)[0]
+            self.__add_on_id = re.findall(r'addon.*?id="([^"]+)"', xml_content, flags=re.DOTALL)[0]
             self.__name = re.findall(r'name="([^"]+)"', xml_content)[0]
 
             self.__description = self.__filter_lang_xmltag('description', xml_content)
@@ -282,7 +282,6 @@ class Addon(KodiStub):
             icon_matches = re.findall(r'<icon>(.*?)</icon>', xml_content, flags=re.DOTALL)
             if icon_matches:
                 self.__icon = os.path.join(self.__add_on_path, icon_matches[0])
-
 
     def __get_settings(self):
         if self.__add_on_id in Addon.__settings:

--- a/xbmcaddon.py
+++ b/xbmcaddon.py
@@ -26,6 +26,12 @@ class Addon(KodiStub):
         # actual live data
         self.__version = None
         self.__name = None
+        self.__author = None
+        self.__icon = None
+        self.__summary = None
+        self.__news = None
+        self.__disclaimer = None
+        self.__description = None
         self.__load_add_on_xml()
         self.__localization = self.__get_strings()
         self.__settings = self.__get_settings()
@@ -158,16 +164,37 @@ class Addon(KodiStub):
 
         Possible options are: author, changelog, description, disclaimer, fanart, icon, id,
                               name, path, profile, stars, summary, type, version
-        """ 
+        """
+        id = id.lower()
 
-        if id == "path":
-            return self.__add_on_path
+        if id == "author":
+            return self.__author
+        elif id == "changelog":
+            return self.__news
+        elif id == "description":
+            return self.__description
+        elif id == "disclaimer":
+            return self.__disclaimer
+        elif id == "fanart":
+            return self.__fanart
+        elif id == "icon":
+            return self.__icon
         elif id == "id":
             return self.__add_on_id
-        elif id == "version":
-            return self.__version
         elif id == "name":
             return self.__name
+        elif id == "path":
+            return self.__add_on_path
+        elif id == "profile":
+            return self.__add_on_profile_path
+        elif id == "stars":
+            pass
+        elif id == "summary":
+            return self.__summary
+        elif id == "type":
+            pass
+        elif id == "version":
+            return self.__version
 
         raise ValueError("Cannot find info '%s'" % (id,))
 
@@ -225,9 +252,48 @@ class Addon(KodiStub):
 
         with io.open(add_on_xml, encoding='utf-8') as fp:
             xml_content = fp.read()
-            self.__version = re.findall(r'version="(\d+.\d+.\d+[^"]*)', xml_content)[0]
+            self.__version = re.findall(r'<addon.*?version="(\d+(?:\.\d)?(?:\.\d)?[^"]*)', xml_content)[0]
             self.__add_on_id = re.findall(r'addon\W+id="([^"]+)"', xml_content)[0]
             self.__name = re.findall(r'name="([^"]+)"', xml_content)[0]
+            tmp = re.findall(r'<addon.*?provider-name="([^"]+)', xml_content)
+            if tmp:
+                self.__author = tmp[0]
+
+            tmp = re.findall(r'<news>(.*?)</news>', xml_content, flags=re.DOTALL)
+            if tmp:
+                self.__news = tmp[0]
+
+            tmp = re.findall(r'<description lang=\"\w+\">(.*?)</description>', xml_content, flags=re.DOTALL)
+            if tmp:
+                for desc in tmp:
+                    lng = desc.strip('"')[1]
+                    if lng == xbmc.getLanguage():
+                        self.__description = desc
+                        break
+                else:
+                    self.__description = tmp[0]
+
+            tmp = re.findall(r'<disclaimer>(.*?)</disclaimer>', xml_content, flags=re.DOTALL)
+            if tmp:
+                self.__disclaimer = tmp[0]
+
+            tmp = re.findall(r'<fanart>(.*?)</fanart>', xml_content, flags=re.DOTALL)
+            if tmp:
+                self.__fanart = tmp[0]
+
+            tmp = re.findall(r'<icon>(.*?)</icon>', xml_content, flags=re.DOTALL)
+            if tmp:
+                self.__icon = tmp[0]
+
+            tmp = re.findall(r'<summary lang=\"\w+\">(.*?)</summary>', xml_content, flags=re.DOTALL)
+            if tmp:
+                for desc in tmp:
+                    lng = desc.strip('"')[1]
+                    if lng == xbmc.getLanguage():
+                        self.__summary = desc
+                        break
+                else:
+                    self.__summary = tmp[0]
 
     def __get_settings(self):
         if self.__add_on_id in Addon.__settings:


### PR DESCRIPTION
### Functional description
implement all infos of xbmcaddon.getAddonInfo, except "stars" and "type" (that i don't understand and never used), also fix for addon version not being recognised in some circumstances.

### Reasoning
xbmcaddon.getAddonInfo was missing lots of info, and gives error if addon version does not respect the pattern x.y.z (while kodi not), for example "1.1"

### Technical description
Just extracted missing info in __load_add_on_xml and used in getAddonInfo, here's some additional info: 
- as descryption and summary could be in many languages, regex capture all of these and search for the default language, if it's not found, use the first encountered
- kodi getAddonInfo id is not case sensitive, so made a id.lower()