### PR TITLE
Fix order of informational Add-on info fields

### DIFF
--- a/xbmc.py
+++ b/xbmc.py
@@ -593,7 +593,7 @@ def get_add_on_info_from_calling_script(add_on_id=None, print_info=False):
         "- Add-on ID:                        {} \n"
         "- Add-on Path:                      {} \n"
         "- Kodi Profile (special://profile): {} \n"
-            .format(a.kodi_home_path, a.kodi_profile_path, a.add_on_id, a.add_on_path),
+            .format(a.kodi_home_path, a.add_on_id, a.add_on_path, a.kodi_profile_path),
         color=Colors.Blue
     )
     return a


### PR DESCRIPTION
### Functional description
<!--- Give a clear explanation of the change, fix or new feature that this PR contains -->
<!--- Put your text below this line -->
The order of the fields in the Add-on info text is incorrect.
<!--- Put your text above this line -->

### Reasoning
<!--- Provide a decent justification for this PR -->
<!--- Put your text below this line -->
I've corrected the order so it matches with the text.

Before:
```
Found Add-on info: 
- Kodi Home (special://home):       /home/michael/Development/plugin.video.viervijfzes/tests/home 
- Add-on ID:                        /home/michael/Development/plugin.video.viervijfzes/tests/home/userdata 
- Add-on Path:                      plugin.video.viervijfzes 
- Kodi Profile (special://profile): /home/michael/Development/plugin.video.viervijfzes 
```

After:
```
Found Add-on info: 
- Kodi Home (special://home):       /home/michael/Development/plugin.video.viervijfzes/tests/home 
- Add-on ID:                        plugin.video.viervijfzes 
- Add-on Path:                      /home/michael/Development/plugin.video.viervijfzes 
- Kodi Profile (special://profile): /home/michael/Development/plugin.video.viervijfzes/tests/home/userdata 

```
<!--- Put your text above this line -->

### Technical description
<!--- Please provide a technical analysis of this PR, explaining the 
 changes that were made. -->
<!--- Put your text below this line -->

<!--- Put your text above this line -->
