### PR TITLE
Indicate that we use the Kodi Matrix API

### DIFF
--- a/xbmc.py
+++ b/xbmc.py
@@ -457,8 +457,8 @@ def getInfoLabel(infoTag):  # NOSONAR
     List of InfoTags - http://kodi.wiki/view/InfoLabels
     """
 
-    if infoTag == "system.buildversion":
-        return "18.1 Git:20160424-c327c53"
+    if infoTag.lower() == "system.buildversion":
+        return "19.0 Git:20200626-xxxxxxxxxx"
 
     return "InfoLabel:{}".format(infoTag)
 


### PR DESCRIPTION
### Functional description
<!--- Give a clear explanation of the change, fix or new feature 
that this PR contains -->
<!--- Put your text below this line -->
This PR changes the `System.BuildVersion` to indicate that we use a Kodi 19 API. This is more correct since we actually implement the Kodi 19 API. It also makes the label case insensitive.
<!--- Put your text above this line -->

### Reasoning
<!--- Provide a decent justification for this PR -->
<!--- Put your text below this line -->
Some addons use the `System.BuildVersion` InfoLabel to be compatible with Kodi 18 and Kodi 19. This aligns the API with the BuildVersion so they can call the right functions.
<!--- Put your text above this line -->

### Technical description
<!--- Please provide a technical analysis of this PR, explaining the 
 changes that were made. -->
<!--- Put your text below this line -->

<!--- Put your text above this line -->
