### PR TITLE
Fix encoding of special characters in ListItems

### DIFF
--- a/xbmcplugin.py
+++ b/xbmcplugin.py
@@ -119,9 +119,9 @@ def addDirectoryItem(handle, url, listitem, isFolder=False, totalItems=0):  # NO
     """
 
     if isFolder:
-        print("*F: %s [%s]" % (KodiStub.replace_colors(str(listitem)), url))
+        print("*F: %s [%s]" % (KodiStub.replace_colors(listitem.__str__()), url))
     else:
-        print("*V: %s [%s]" % (KodiStub.replace_colors(str(listitem)), url))
+        print("*V: %s [%s]" % (KodiStub.replace_colors(listitem.__str__()), url))
 
     handle_info = __handle_info.get(handle, dict())
     handle_info["count"] = handle_info.get("count", 0) + 1


### PR DESCRIPTION
### Functional description
<!--- Give a clear explanation of the change, fix or new feature 
that this PR contains -->
<!--- Put your text below this line -->
I have ListItems with international characters (like Café De Mol), when I pass them trough sake, I get an exception when displaying them.

It seems that calling `str(listitem)` returns an incorrect representation of the label, while calling `listitem.__str__()` works fine. I'm not sure if this is the right fix. Maybe you know what's going on here?

I'm testing on Python 2.7 here.

<!--- Put your text above this line -->

### Reasoning
<!--- Provide a decent justification for this PR -->
<!--- Put your text below this line -->

<!--- Put your text above this line -->

### Technical description
<!--- Please provide a technical analysis of this PR, explaining the 
 changes that were made. -->
<!--- Put your text below this line -->
Stacktrace:
```
  File "/home/michael/Development/kodi.emulator.ascii/xbmcplugin.py", line 126, in addDirectoryItem
    print("*F: %s [%s]" % (KodiStub.replace_colors(str(listitem)), url))
UnicodeEncodeError: 'ascii' codec can't encode character u'\xe9' in position 3: ordinal not in range(128)
```
<!--- Put your text above this line -->
