### PR TITLE
Set internal encoding to UTF-8 on Python 2

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: CC-BY-NC-SA-4.0
+
+__all__ = ["test_unicode"]

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,3 +1,10 @@
 # SPDX-License-Identifier: CC-BY-NC-SA-4.0
 
+import sys
+
+# Make UTF-8 the default encoding in Python 2
+if sys.version_info[0] == 2:
+    reload(sys)
+    sys.setdefaultencoding("utf-8")
+
 __all__ = ["test_unicode"]

--- a/tests/test_unicode.py
+++ b/tests/test_unicode.py
@@ -10,5 +10,7 @@ class TestUnicode(unittest.TestCase):
 
     def test_unicode(self):
         for label in ['saké', u'saké', '酒', u'酒']:
-            li = xbmcgui.ListItem(label=label, path='plugin://plugin.video.example/test')
+            li = xbmcgui.ListItem(label=label, path='plugin://plugin.video.example/' + label)
             xbmcplugin.addDirectoryItem(-1, li.getPath(), li)
+
+        xbmcplugin.endOfDirectory(-1)

--- a/tests/test_unicode.py
+++ b/tests/test_unicode.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: GPL-3.0
+import unittest
+
+import xbmcgui
+import xbmcplugin
+
+
+class TestUnicode(unittest.TestCase):
+
+    def test_unicode(self):
+        for label in ['saké', u'saké', '酒', u'酒']:
+            li = xbmcgui.ListItem(label=label, path='plugin://plugin.video.example/test')
+            xbmcplugin.addDirectoryItem(-1, li.getPath(), li)

--- a/xbmcgui.py
+++ b/xbmcgui.py
@@ -338,12 +338,8 @@ class ListItem(KodiStub):
             for key in keys:
                 value = "%s    - %s: %s\n" % (value, key, self.__properties[key])
 
-            if self.PY2:
-                return value.encode('utf-8') if isinstance(value, unicode) else value
             return value
         else:
-            if self.PY2:
-                return self.__label.encode('utf-8') if isinstance(self.__label, unicode) else self.__label
             return self.__label
 
     def __unicode__(self):

--- a/xbmcgui.py
+++ b/xbmcgui.py
@@ -339,11 +339,11 @@ class ListItem(KodiStub):
                 value = "%s    - %s: %s\n" % (value, key, self.__properties[key])
 
             if self.PY2:
-                return value.encode('utf-8') if type(value) == unicode else value
+                return value.encode('utf-8') if isinstance(value, unicode) else value
             return value
         else:
             if self.PY2:
-                return self.__label.encode('utf-8') if type(self.__label) == unicode else self.__label
+                return self.__label.encode('utf-8') if isinstance(self.__label, unicode) else self.__label
             return self.__label
 
     def __unicode__(self):

--- a/xbmcgui.py
+++ b/xbmcgui.py
@@ -338,8 +338,12 @@ class ListItem(KodiStub):
             for key in keys:
                 value = "%s    - %s: %s\n" % (value, key, self.__properties[key])
 
+            if self.PY2:
+                return value.encode('utf-8') if type(value) == unicode else value
             return value
         else:
+            if self.PY2:
+                return self.__label.encode('utf-8') if type(self.__label) == unicode else self.__label
             return self.__label
 
     def __unicode__(self):


### PR DESCRIPTION
### Functional description
<!--- Give a clear explanation of the change, fix or new feature that this PR contains -->
<!--- Put your text below this line -->
Follow up from #15 

I have ListItems with international characters (like Café De Mol), when I pass them trough sake, I get an exception when displaying them. This seems to happen when the labels are encoded as `unicode` instead of a `str`. Calling `str(listitem)` expect this to be a `str` in Python 2.

A solution is to make sure that the `__str__()` function actually returns a `str` in Python 2. This PR does just that, and adds a tests for this. The test fails without the code change.

<!--- Put your text above this line -->

### Reasoning
<!--- Provide a decent justification for this PR -->
<!--- Put your text below this line -->

<!--- Put your text above this line -->

### Technical description
<!--- Please provide a technical analysis of this PR, explaining the 
 changes that were made. -->
<!--- Put your text below this line -->
Stacktrace:
```
  File "/home/michael/Development/kodi.emulator.ascii/xbmcplugin.py", line 126, in addDirectoryItem
    print("*F: %s [%s]" % (KodiStub.replace_colors(str(listitem)), url))
UnicodeEncodeError: 'ascii' codec can't encode character u'\xe9' in position 3: ordinal not in range(128)
```
<!--- Put your text above this line -->
