### PR TITLE
Return empty string when requesting an invalid setting key

### DIFF
--- a/xbmcaddon.py
+++ b/xbmcaddon.py
@@ -45,13 +45,10 @@ class Addon(KodiStub):
         :rtype: str
 
         """
-
         if id in self.__settings:
             return self.__settings[id]
         else:
-            return None
-            # Or we raise an error?
-            # raise ValueError("Cannot find setting '%s'" % (setting_id, ))
+            return ''
 
     def getSettingBool(self, id):
         """ Returns the value of a setting as a boolean.


### PR DESCRIPTION
### Functional description
<!--- Give a clear explanation of the change, fix or new feature 
that this PR contains -->
<!--- Put your text below this line -->

<!--- Put your text above this line -->

### Reasoning
<!--- Provide a decent justification for this PR -->
<!--- Put your text below this line -->
It seems that Kodi returns an empty string when requesting a setting key that doesn't exist.
<!--- Put your text above this line -->

### Technical description
<!--- Please provide a technical analysis of this PR, explaining the 
 changes that were made. -->
<!--- Put your text below this line -->

<!--- Put your text above this line -->
