### PR TITLE
Make Monitor.waitForAbort return sooner when an abort has been requested

### DIFF
--- a/xbmc.py
+++ b/xbmc.py
@@ -84,8 +84,13 @@ class Monitor(KodiStub):
 
         """
 
-        time.sleep(seconds)
-        return self.__abort
+        deadline = time.time() + seconds
+        while time.time() < deadline:
+            if self.__abort:
+                return True
+            time.sleep(0.1)  # Sleep 100ms
+
+        return False
 
 
 # noinspection PyPep8Naming


### PR DESCRIPTION
### Functional description
<!--- Give a clear explanation of the change, fix or new feature 
that this PR contains -->
<!--- Put your text below this line -->
The current implementation for `Monitor.waitForAbort()` always waits for the full timeout before returning.  This changes this to check every 100ms. It also returns immediately when an abort has already been requested/
<!--- Put your text above this line -->

### Reasoning
<!--- Provide a decent justification for this PR -->
<!--- Put your text below this line -->
This fixes the `Monitor.waitForAbort()` behavior to do what it also is doing in Kodi.

This also allows you to use `timeout -s SIGINT 10 python service_entry.py` to launch a service and have it properly terminate after 10 seconds.
<!--- Put your text above this line -->

### Technical description
<!--- Please provide a technical analysis of this PR, explaining the 
 changes that were made. -->
<!--- Put your text below this line -->

<!--- Put your text above this line -->
