### PR TITLE
Implement Player.getPlayingFile()

### DIFF
--- a/xbmc.py
+++ b/xbmc.py
@@ -283,22 +283,24 @@ class Player(KodiStub):
         self.onAVStarted()
 
     def isPlaying(self):  # NOSONAR
-        # type: () -> bool
-        """
-        Check Kodi is playing something.
+        """ Check Kodi is playing something.
 
         :return: True if Kodi is playing a file.
+        :rtype: bool
         """
         return self.play_started
 
-    def onAVStarted(self):  # NOSONAR
-        # type: () -> None
+    def getPlayingFile(self):  # NOSONAR
+        """ Returns the current playing file as a string.
+
+        :return: The filename of the playing item.
+        :rtype: str
         """
-        onAVStarted method.
+        return Player.playing_file if self.play_started else None
 
+    def onAVStarted(self):  # NOSONAR
+        """ onAVStarted method.
         Will be called when Kodi has a video or audiostream.
-
-        New function added.
         """
         pass
 

--- a/xbmc.py
+++ b/xbmc.py
@@ -250,6 +250,8 @@ class PlayList(KodiStub):
 
 # noinspection PyPep8Naming,PyArgumentList
 class Player(KodiStub):
+    playing_file = None
+
     def __init__(self, *args, **kwargs):
         super(Player, self).__init__()
 

--- a/xbmcplugin.py
+++ b/xbmcplugin.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: GPL-3.0
 
-from xbmc import Player
 from xbmcgui import ListItem
 from sakee.stub import KodiStub
 from sakee.colors import Colors
@@ -258,6 +257,7 @@ def setResolvedUrl(handle, succeeded, listitem):  # NOSONAR
     :param ListItem listitem:   Item the file plugin resolved to for playback.
 
     """
+    from xbmc import Player
 
     if succeeded:
         KodiStub.print_line("Item resolved to: {}".format(listitem), color=Colors.Blue)

--- a/xbmcplugin.py
+++ b/xbmcplugin.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: GPL-3.0
 
+from xbmc import Player
 from xbmcgui import ListItem
 from sakee.stub import KodiStub
 from sakee.colors import Colors
@@ -260,8 +261,10 @@ def setResolvedUrl(handle, succeeded, listitem):  # NOSONAR
 
     if succeeded:
         KodiStub.print_line("Item resolved to: {}".format(listitem), color=Colors.Blue)
+        Player.playing_file = listitem.getPath()
     else:
         KodiStub.print_line("Item failed to resolve: {}".format(listitem), color=Colors.Red)
+        Player.playing_file = None
 
 
 # noinspection PyPep8Naming,PyUnusedLocal


### PR DESCRIPTION
### Functional description
<!--- Give a clear explanation of the change, fix or new feature 
that this PR contains -->
<!--- Put your text below this line -->
This adds an implementation for `Player.getPlayingFile()`
<!--- Put your text above this line -->

### Reasoning
<!--- Provide a decent justification for this PR -->
<!--- Put your text below this line -->
My add-on currently calls `Player.getPlayingFile()` to get the currently playing file to know when the subtitles can be enabled. This method was not implemented.
<!--- Put your text above this line -->

### Technical description
<!--- Please provide a technical analysis of this PR, explaining the 
 changes that were made. -->
<!--- Put your text below this line -->
I've added a static `Player.playing_file` variable that is set when setResolvedUrl is called. This string will be returned after a few seconds when the Player has started fake-playing.
<!--- Put your text above this line -->
