### PR TITLE
Allow passing None as nolabel and yeslabel in Dialog.yesno()

### DIFF
--- a/xbmcgui.py
+++ b/xbmcgui.py
@@ -107,7 +107,7 @@ class Dialog(KodiStub):
         return list(map(lambda index_value: int(index_value), selections.split(",")))[0]
 
     # noinspection PyUnusedLocal
-    def yesno(self, heading, message, nolabel="No", yeslabel="Yes", customlabel=None, autoclose=0):
+    def yesno(self, heading, message, nolabel=None, yeslabel=None, customlabel=None, autoclose=0):
         """ The Yes / No dialog can be used to inform the user about questions and get the answer.
 
         :param str heading:             Dialog heading.
@@ -121,6 +121,12 @@ class Dialog(KodiStub):
         :rtype: bool
 
         """
+
+        if nolabel is None:
+            nolabel = "No"
+
+        if yeslabel is None:
+            yeslabel = "Yes"
 
         self.print_heading(heading)
         question = "{} [{}]{} or [{}]{}:".format(message, yeslabel[0], yeslabel[1:], nolabel[0], nolabel[1:])

--- a/xbmcgui.py
+++ b/xbmcgui.py
@@ -107,7 +107,7 @@ class Dialog(KodiStub):
         return list(map(lambda index_value: int(index_value), selections.split(",")))[0]
 
     # noinspection PyUnusedLocal
-    def yesno(self, heading, message, nolabel=None, yeslabel=None, customlabel=None, autoclose=0):
+    def yesno(self, heading, message, nolabel='', yeslabel='', customlabel=None, autoclose=0):
         """ The Yes / No dialog can be used to inform the user about questions and get the answer.
 
         :param str heading:             Dialog heading.
@@ -122,10 +122,10 @@ class Dialog(KodiStub):
 
         """
 
-        if nolabel is None:
+        if not nolabel:
             nolabel = "No"
 
-        if yeslabel is None:
+        if not yeslabel:
             yeslabel = "Yes"
 
         self.print_heading(heading)


### PR DESCRIPTION
### Functional description
<!--- Give a clear explanation of the change, fix or new feature 
that this PR contains -->
<!--- Put your text below this line -->
I'm not really sure if this is the correct fix, but Kodi seems to handle a `None` value fine as `nolabel` and `yeslabel`. When implemented with defaults, passing `None` will override the default and will give an error.

<!--- Put your text above this line -->

### Reasoning
<!--- Provide a decent justification for this PR -->
<!--- Put your text below this line -->
Python overrides the defaults arguments when None is passed, so it makes sense to apply a default when the value is None.
<!--- Put your text above this line -->

### Technical description
<!--- Please provide a technical analysis of this PR, explaining the 
 changes that were made. -->
<!--- Put your text below this line -->
```
...

  File "/home/runner/work/plugin.video.vtm.go/plugin.video.vtm.go/resources/lib/modules/player.py", line 179, in _check_credentials
    confirm = self._kodi.show_yesno_dialog(message=self._kodi.localize(30701))
  File "/home/runner/work/plugin.video.vtm.go/plugin.video.vtm.go/resources/lib/kodiwrapper.py", line 268, in show_yesno_dialog
    return Dialog().yesno(heading=heading, message=message, nolabel=nolabel, yeslabel=yeslabel, autoclose=autoclose)
  File "/opt/hostedtoolcache/Python/2.7.18/x64/lib/python2.7/site-packages/xbmcgui.py", line 126, in yesno
    question = "{} [{}]{} or [{}]{}:".format(message, yeslabel[0], yeslabel[1:], nolabel[0], nolabel[1:])
TypeError: 'NoneType' object has no attribute '__getitem__'
```
<!--- Put your text above this line -->
