### PR TITLE
Implement xbmc.Player

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<addon id="plugin.video.example" name="Example" version="1.0.0" provider-name="Sake">
+</addon>

--- a/sakee/__init__.py
+++ b/sakee/__init__.py
@@ -1,3 +1,3 @@
 # SPDX-License-Identifier: GPL-3.0
 
-__all__ = ["colors", "stub", "sakejsonrpc"]
+__all__ = ["colors", "stub", "sakejsonrpc", "internalplayer"]

--- a/sakee/internalplayer.py
+++ b/sakee/internalplayer.py
@@ -1,0 +1,140 @@
+# SPDX-License-Identifier: GPL-3.0
+
+import threading
+from .stub import KodiStub
+
+
+class KodiInteralPlayer(KodiStub):  # NOSONAR
+    STATUS_INIT = 'init'
+    STATUS_STOPPED = 'stopped'
+    STATUS_PLAYING = 'playing'
+    STATUS_PAUSED = 'paused'
+    __kodi_player = None
+
+    @staticmethod
+    def instance():
+        """ The Kodi player instance
+
+        :return: The stub for the internal Kodi player
+        :rtype: KodiInteralPlayer
+
+        """
+
+        if KodiInteralPlayer.__kodi_player is None:
+            KodiInteralPlayer.__kodi_player = KodiInteralPlayer()
+
+        return KodiInteralPlayer.__kodi_player
+
+    def __init__(self):
+        super(KodiInteralPlayer, self).__init__()
+
+        self.status = KodiInteralPlayer.STATUS_STOPPED
+        self.file = None
+        self.current_time = 0
+        self.total_time = 0
+
+        self._stop_event = threading.Event()
+
+        # Keep track of players
+        self.__players = []
+
+        # The play thread
+        self.__play_thread = None
+        self.__kill_play_thread = False
+
+    # noinspection PyUnusedLocal
+    def play_resolved_item(self, path, item):  # NOSONAR
+        """ Sets the resolved item to play
+
+        :param str path:
+        :param ListItem item:
+
+        """
+
+        self.file = path
+        self.play(path)
+
+    def play(self, path):
+        self.file = path
+        self.status = KodiInteralPlayer.STATUS_INIT
+        self.total_time = 5  # 5 seconds
+        self._stop_event.clear()
+
+        # Start the playback simulation thread
+        self.__play_thread = threading.Thread(target=self.__loop)
+        self.__play_thread.start()
+
+    def stop_playback(self, force=False):
+        """ Stops playback. If `force=True` no stop events are raised.
+
+        :param bool force:      Force stops the player.
+
+        """
+
+        if self.__play_thread is None:
+            return
+
+        if force and self.__play_thread:
+            self.__kill_play_thread = True
+            return
+
+        self._stop_event.set()
+        self.__play_thread.join(2)
+        self.__play_thread = None
+        self.__kill_play_thread = False
+
+    def register_player(self, player):
+        """ Register a xbmc.Player instance
+
+        :param Player player: The player to register
+
+        """
+
+        self.__players.append(player)
+
+    def unregister_player(self, player):
+        """ Unregister a xbmc.Player instance
+
+        :param Player player: The player to unregister
+
+        """
+
+        self.__players.remove(player)
+
+    def __loop(self):
+        """ Background playback loop. """
+        from datetime import timedelta
+
+        for player in self.__players:
+            player.onPlayBackStarted()
+
+        while not self._stop_event.wait(1):
+            if self.__kill_play_thread:
+                return
+
+            KodiStub.print_line(
+                'Player: [{status}] {pos}/{total}'.format(
+                    status=self.status,
+                    pos=timedelta(seconds=self.current_time),
+                    total=timedelta(seconds=self.total_time)
+                ), verbose=True)
+
+            if self.status == KodiInteralPlayer.STATUS_INIT:
+                self.status = KodiInteralPlayer.STATUS_PLAYING
+                self.current_time = 0
+                for player in self.__players:
+                    player.onAVStarted()
+                    player.onAVChange()
+                continue
+
+            if self.status == KodiInteralPlayer.STATUS_PLAYING:
+                self.current_time += 1
+                if self.current_time > self.total_time:
+                    for player in self.__players:
+                        player.stop()
+
+            if self.status == KodiInteralPlayer.STATUS_STOPPED:
+                break
+
+        for player in self.__players:
+            player.onPlayBackStopped()

--- a/tests/test_xbmc_player.py
+++ b/tests/test_xbmc_player.py
@@ -1,0 +1,49 @@
+# SPDX-License-Identifier: GPL-3.0
+import time
+import unittest
+
+import xbmc
+import xbmcgui
+import xbmcplugin
+
+
+class TestXbmcPlayer(unittest.TestCase):
+
+    def test_player(self):
+        filename = '/tmp/file1.mov'
+
+        player = xbmc.Player()
+
+        # Start playback trough a setResolvedFile
+        li = xbmcgui.ListItem(label='Label', path=filename)
+        xbmcplugin.setResolvedUrl(-1, True, li)
+
+        # Wait for up to 5 seconds until the Player started playing
+        deadline = time.time() + 5
+        while deadline > time.time():
+            if player.isPlaying():
+                break
+            time.sleep(0.1)  # Sleep 100ms
+
+        self.assertEqual(player.isPlaying(), True)
+        self.assertEqual(player.isPlayingVideo(), True)
+
+        # Check if we have the right file
+        self.assertEqual(player.getPlayingFile(), filename)
+
+        # Hit pause, we should be paused now
+        player.pause()
+        self.assertEqual(player.isPlaying(), False)
+
+        # Seek to 3 seconds
+        player.seekTime(3)
+        self.assertEqual(player.getTime(), 3)
+
+        # Hit pause again, we should be playing again
+        player.pause()
+        self.assertEqual(player.isPlaying(), True)
+
+        # Hit stop
+        player.stop()
+        self.assertEqual(player.isPlaying(), False)
+        self.assertEqual(player.isPlayingVideo(), False)

--- a/xbmc.py
+++ b/xbmc.py
@@ -2,16 +2,15 @@
 
 import io
 import json
-import threading
-import time
 import os
 import signal
+import threading
+import time
 from collections import namedtuple
-
-from xbmcgui import ListItem
 
 from sakee.colors import Colors
 from sakee.stub import KodiStub
+from xbmcgui import ListItem
 
 DRIVE_NOT_READY = 1
 ENGLISH_NAME = 2
@@ -40,10 +39,10 @@ TRAY_OPEN = 16
 
 # Custom AddonData type
 AddonData = namedtuple('AddonData', [
-    'kodi_home_path',       # data path (either portable of user path)
-    'add_on_id',            # the add-on id
-    'add_on_path',          # the full path to the add-on
-    'kodi_profile_path'     # the full path to the add-on profile folder
+    'kodi_home_path',  # data path (either portable of user path)
+    'add_on_id',  # the add-on id
+    'add_on_path',  # the full path to the add-on
+    'kodi_profile_path'  # the full path to the add-on profile folder
 ])
 
 
@@ -58,6 +57,7 @@ class Monitor(KodiStub):
         # noinspection PyUnusedLocal
         def stop_requested(signum, frame):
             self.__abort = True
+            Player.stop()
 
         # Requires PyCharm to set the option of "Emulate terminal in output window" to work
         signal.signal(signal.SIGINT, stop_requested)
@@ -250,24 +250,230 @@ class PlayList(KodiStub):
 
 # noinspection PyPep8Naming,PyArgumentList
 class Player(KodiStub):
-    playing_file = None
+    _STATUS_INIT = 'init'
+    _STATUS_STOPPED = 'stopped'
+    _STATUS_PLAYING = 'playing'
+    _STATUS_PAUSED = 'paused'
 
-    def __init__(self, *args, **kwargs):
+    _stop_event = threading.Event()
+
+    __instance = None
+    __status = _STATUS_STOPPED
+    __file = None
+    __current_time = 0
+    __total_time = 0
+
+    def __init__(self):
         super(Player, self).__init__()
 
-        self.Init(*args, **kwargs)
-        self.play_started = False
+        # Keep track of the last so we can notify it when something happens.
+        Player.__instance = self
 
-        def play_start():
-            self.play_started = True
-            self.onAVStarted()
+    @classmethod
+    def __playback_loop(cls):
+        """ Emulate a player that is playing a file. """
+        def loop():
+            """ Background playback loop. """
+            from datetime import timedelta
 
-        timer = threading.Timer(2.0, play_start)
-        timer.start()
+            cls.__instance.onPlayBackStarted() if cls.__instance else None
+
+            while not cls._stop_event.wait(1):
+                cls.print_line('Player: [{status}] {pos}/{total}'.format(status=cls.__status,
+                                                                         pos=timedelta(seconds=cls.__current_time),
+                                                                         total=timedelta(seconds=cls.__total_time)),
+                               verbose=True)
+
+                if cls.__status == cls._STATUS_INIT:
+                    cls.__status = cls._STATUS_PLAYING
+                    cls.__current_time = 0
+                    cls.__instance.onAVStarted() if cls.__instance else None
+                    cls.__instance.onAVChange() if cls.__instance else None
+                    continue
+
+                if cls.__status == cls._STATUS_PLAYING:
+                    cls.__current_time += 1
+                    if cls.__current_time > cls.__total_time:
+                        cls.stop()
+
+                if cls.__status == cls._STATUS_STOPPED:
+                    break
+
+            cls.__instance.onPlayBackStopped() if cls.__instance else None
+
+        # Start the background thread
+        cls._stop_event.clear()
+        background_thread = threading.Thread(target=loop)
+        background_thread.start()
+
+    @classmethod
+    def getAvailableAudioStreams(cls):  # NOSONAR
+        """ Returns the available audio stream names.
+
+        :return: The available audio streams.
+        :rtype: List[str]
+        """
+        return []  # Not implemented
+
+    @classmethod
+    def getAvailableSubtitleStreams(cls):  # NOSONAR
+        """ Returns the available subtitle stream names.
+
+        :return: The available subtitle streams.
+        :rtype: List[str]
+        """
+        return []  # Not implemented
+
+    @classmethod
+    def getAvailableVideoStreams(cls):  # NOSONAR
+        """ Returns the available video stream names.
+
+        :return: The available video streams.
+        :rtype: List[str]
+        """
+        return []  # Not implemented
+
+    @classmethod
+    def getMusicInfoTag(cls):
+        """ Return the music info tag.
+
+        :return: Returns the MusicInfoTag of the current playing 'Song'.
+        :rtype: MusicInfoTag
+        """
+        if cls.__status == cls._STATUS_STOPPED:
+            raise Exception('Player is not playing a file.')
+
+        return None  # Not implemented
+
+    @classmethod
+    def getPlayingFile(cls):  # NOSONAR
+        """ Returns the current playing file as a string.
+
+        :return: The filename of the playing item.
+        :rtype: str
+        """
+        return cls.__file
+
+    @classmethod
+    def getRadioRDSInfoTag(cls):
+        """ Return the Radio RDS info tag.
+
+        :return: Returns the RadioRDSInfoTag of the current playing 'Radio Song if. present'.
+        :rtype: RadioRDSInfoTag
+        """
+        if cls.__status == cls._STATUS_STOPPED:
+            raise Exception('Player is not playing a file.')
+
+        return None  # Not implemented
+
+    @classmethod
+    def getSubtitles(cls):
+        """ Return the subtitle stream name.
+
+        :return: Stream name
+        :rtype: str
+        """
+        return ''  # Not implemented
+
+    @classmethod
+    def getTime(cls):
+        """ Return the current playing time.
+
+        :return: Returns the current time of the current playing media as fractional seconds.
+        :rtype: int
+        """
+        return cls.__current_time
+
+    @classmethod
+    def getTotalTime(cls):
+        """ Return the total playing time.
+
+        :return: Returns the total time of the current playing media in seconds. This is only accurate to the full second.
+        :rtype: int
+        """
+        if cls.__status == cls._STATUS_STOPPED:
+            raise Exception('Player is not playing a file.')
+
+        return cls.__total_time
+
+    @classmethod
+    def getVideoInfoTag(cls):
+        """ Return the video info tag.
+
+        :return:     The VideoInfoTag of the current playing Movie.
+        :rtype VideoInfoTag
+        """
+        if cls.__status == cls._STATUS_STOPPED:
+            raise Exception('Player is not playing a file.')
+
+        return None  # Not implemented
+
+    @classmethod
+    def isExternalPlayer(cls):
+        """ Check for external player.
+
+        :return:     True if kodi is playing using an external player.
+        :rtype bool
+        """
+        return False
+
+    @classmethod
+    def isPlaying(cls):  # NOSONAR
+        """ Check Kodi is playing something.
+
+        :return:    True if Kodi is playing a file.
+        :rtype: bool
+        """
+        return cls.__status == cls._STATUS_PLAYING
+
+    @classmethod
+    def isPlayingAudio(cls):  # NOSONAR
+        """ Check for playing audio.
+
+        :return:    True if Kodi is playing an audio file.
+        :rtype: bool
+        """
+        return cls.__status == cls._STATUS_PLAYING
+
+    @classmethod
+    def isPlayingRDS(cls):  # NOSONAR
+        """ Check for playing radio data system (RDS).
+
+        :return:    True if kodi is playing a radio data system (RDS).
+        :rtype: bool
+        """
+        return cls.__status == cls._STATUS_PLAYING
+
+    @classmethod
+    def isPlayingVideo(cls):  # NOSONAR
+        """ Check for playing video.
+
+        :return: True if Kodi is playing a video.
+        :rtype: bool
+        """
+        return cls.__status == cls._STATUS_PLAYING
+
+    @classmethod
+    def pause(cls):  # NOSONAR
+        """ Pause or resume playing if already paused.
+        """
+        if cls.__status == cls._STATUS_STOPPED:
+            return
+
+        if cls.__status == cls._STATUS_PLAYING:
+            cls.__status = cls._STATUS_PAUSED
+            cls.__instance.onPlayBackPaused() if cls.__instance else None
+            return
+
+        if cls.__status == cls._STATUS_PAUSED:
+            cls.__status = cls._STATUS_PLAYING
+            cls.__instance.onPlayBackResumed() if cls.__instance else None
+            return
 
     # noinspection PyUnusedLocal
-    def play(self, item=None, listitem=None, windowed=False, startpos=-1):
-        """ Play a item.
+    @classmethod
+    def play(cls, item=None, listitem=None, windowed=False, startpos=-1):
+        """ Play an item.
 
         :param str|None item:            Filename, url or playlist
         :param ListItem|None listitem:   Used with setInfo() to set different infolabels.
@@ -280,31 +486,194 @@ class Player(KodiStub):
         Once you use a keyword, all following arguments require the keyword.
 
         """
+        # Stop playing the current file (if any)
+        cls.stop()
 
-        time.sleep(1)
-        self.onAVStarted()
+        cls.__file = item
+        cls.__status = cls._STATUS_INIT
+        cls.__total_time = 5  # 5 seconds
+        cls.__playback_loop()
 
-    def isPlaying(self):  # NOSONAR
-        """ Check Kodi is playing something.
-
-        :return: True if Kodi is playing a file.
-        :rtype: bool
+    @classmethod
+    def playnext(cls):  # NOSONAR
+        """ Play next item in playlist.
         """
-        return self.play_started
+        pass  # Not implemented
 
-    def getPlayingFile(self):  # NOSONAR
-        """ Returns the current playing file as a string.
-
-        :return: The filename of the playing item.
-        :rtype: str
+    @classmethod
+    def playprevious(cls):  # NOSONAR
+        """ Play previous item in playlist.
         """
-        return Player.playing_file if self.play_started else None
+        pass  # Not implemented
+
+    @classmethod
+    def playselected(cls, selected):  # NOSONAR
+        """ Set Audio Stream.
+
+        :param int selected:            Item to select
+        """
+        pass  # Not implemented
+
+    @classmethod
+    def seekTime(cls, seekTime):  # NOSONAR
+        """ Seek time.
+
+        Seeks the specified amount of time as fractional seconds.
+        The time specified is relative to the beginning of the currently. playing media file.
+
+        :param int seekTime:            Time to seek as fractional seconds
+        """
+        if cls.__status == cls._STATUS_STOPPED:
+            raise Exception('Player is not playing a file.')
+
+        cls.__current_time = seekTime
+        cls.__instance.onPlayBackSeek(seekTime, 0) if cls.__instance else None
+
+    @classmethod
+    def setAudioStream(cls, stream):  # NOSONAR
+        """ Set Audio Stream.
+
+        :param int stream:              Audio stream to select for play
+        """
+        pass  # Not implemented
+
+    @classmethod
+    def setSubtitles(cls, subtitleFile):  # NOSONAR
+        """ Set subtitle file and enable subtitles.
+
+        :param str subtitleFile:        File to use as source of subtitles
+        """
+        pass  # Not implemented
+
+    @classmethod
+    def setSubtitleStream(cls, stream):  # NOSONAR
+        """ Set Subtitle Stream.
+
+        :param int stream:              Subtitle stream to select for play
+        """
+        pass  # Not implemented
+
+    @classmethod
+    def setVideoStream(cls, stream):  # NOSONAR
+        """ Set Video Stream.
+
+        :param int stream:              Video stream to select for play
+        """
+        pass  # Not implemented
+
+    @classmethod
+    def showSubtitles(cls, visible):  # NOSONAR
+        """ Enable / disable subtitles.
+
+        :param bool visible:            True for visible subtitles.
+        """
+        pass  # Not implemented
+
+    @classmethod
+    def stop(cls):  # NOSONAR
+        """ Stop playing.
+        """
+        cls.__status = cls._STATUS_STOPPED
+        cls.__current_time = 0
+        cls.__total_time = 0
+        cls.__file = None
+
+        cls._stop_event.set()
+
+    @classmethod
+    def updateInfoTag(cls, item):  # NOSONAR
+        """ Update info labels for currently playing item.
+
+        :param ListItem item:           ListItem with new info
+        """
+        if cls.__status == cls._STATUS_STOPPED:
+            raise Exception('Player is not playing a file.')
+
+        # Not implemented
+
+    def onAVChange(self):  # NOSONAR
+        """ onAVChange method.
+        Will be called when Kodi has a video, audio or subtitle stream. Also happens when the stream changes.
+        """
+        self.print_line('Invoked onAVChange()', verbose=True)
 
     def onAVStarted(self):  # NOSONAR
         """ onAVStarted method.
         Will be called when Kodi has a video or audiostream.
         """
-        pass
+        self.print_line('Invoked onAVStarted()', verbose=True)
+
+    def onPlaybackEnded(self):  # NOSONAR
+        """ onPlaybackEnded method.
+        Will be called when Kodi stops playing a file.
+        """
+        self.print_line('Invoked onPlaybackEnded()', verbose=True)
+
+    def onPlayBackError(self):  # NOSONAR
+        """ onPlayBackError method.
+        Will be called when playback stops due to an error.
+        """
+        self.print_line('Invoked onPlayBackError()', verbose=True)
+
+    def onPlayBackPaused(self):  # NOSONAR
+        """ onPlayBackPaused method.
+        Will be called when user pauses a playing file.
+        """
+        self.print_line('Invoked onPlayBackPaused()', verbose=True)
+
+    def onPlayBackResumed(self):  # NOSONAR
+        """ onPlayBackResumed method.
+        Will be called when user resumes a paused file.
+        """
+        self.print_line('Invoked onPlayBackResumed()', verbose=True)
+
+    def onPlayBackSeek(self, time, seekOffset):  # NOSONAR
+        """ onPlayBackSeek method.
+        Will be called when user seeks to a time.
+
+        :param int time:            Time to seek to
+        :param int seekOffset:      ?
+        """
+        self.print_line('Invoked onPlayBackSeek(%d, %d)' % (time, seekOffset), verbose=True)
+
+    def onPlayBackSeekChapter(self, chapter):  # NOSONAR
+        """ onPlayBackSeekChapter method.
+        Will be called when user performs a chapter seek.
+
+        :param int chapter:         Chapter to seek to
+        """
+        self.print_line('Invoked onPlayBackSeekChapter(%d)' % chapter, verbose=True)
+
+    def onPlayBackSpeedChanged(self, speed):  # NOSONAR
+        """ onPlayBackSpeedChanged method.
+        Will be called when players speed changes (eg. user FF/RW).
+
+        Negative speed means player is rewinding, 1 is normal playback speed.
+
+        :param int speed:           Current speed of player
+        """
+        self.print_line('Invoked onPlayBackSpeedChanged(%d)' % speed, verbose=True)
+
+    def onPlayBackStarted(self):  # NOSONAR
+        """ onPlayBackStarted method.
+        Will be called when Kodi player starts. Video or audio might not be available at this point.
+
+        Use onAVStarted() instead if you need to detect if Kodi is actually playing a media file
+        (i.e, if a stream is available).
+        """
+        self.print_line('Invoked onPlayBackStarted()', verbose=True)
+
+    def onPlayBackStopped(self):  # NOSONAR
+        """ onPlayBackStopped method.
+        Will be called when user stops Kodi playing a file.
+        """
+        self.print_line('Invoked onPlayBackStopped()', verbose=True)
+
+    def onQueueNextItem(self):  # NOSONAR
+        """ onQueueNextItem method.
+        Will be called when user queues the next item.
+        """
+        self.print_line('Invoked onQueueNextItem()', verbose=True)
 
 
 # noinspection PyPep8Naming

--- a/xbmcgui.py
+++ b/xbmcgui.py
@@ -75,7 +75,8 @@ class Dialog(KodiStub):
             self.print_line("{} ) {}".format(i, options[i]))
             selections.append(str(i))
         self.print_line("=" * 120, color=Colors.Yellow)
-        selections = self.read_input("What items to select (%s)? " % (",".join(selections)), color=Colors.Yellow).lower()
+        selections = self.read_input("What items to select (%s)? " % (",".join(selections)),
+                                     color=Colors.Yellow).lower()
         if not selections:
             return None
         return list(map(lambda index_value: int(index_value), selections.split(",")))
@@ -189,7 +190,7 @@ class ListItem(KodiStub):
         self.__subtitles = []
 
         # store properties
-        self.__properties = {}
+        self.__properties = {"path": path}
 
     def setIconImage(self, icon):  # NOSONAR
         raise DeprecationWarning("No more setIconImage: http://kodi.wiki/view/Jarvis_API_changes")
@@ -330,7 +331,7 @@ class ListItem(KodiStub):
         :rtype: str
         """
 
-        return self.__path or ""
+        return self.__path or self.getProperty("path") or ""
 
     def __str__(self):
         if KodiStub.is_verbose:
@@ -390,7 +391,7 @@ class DialogProgress(KodiStub):
 
     def close(self):
         """ Close the progress dialog. """
-        self.print_line("="*120, color=Colors.Yellow)
+        self.print_line("=" * 120, color=Colors.Yellow)
 
     def iscanceled(self):
         """ Checks progress is canceled. """

--- a/xbmcplugin.py
+++ b/xbmcplugin.py
@@ -1,9 +1,8 @@
 # SPDX-License-Identifier: GPL-3.0
 
-from xbmcgui import ListItem
-from sakee.stub import KodiStub
 from sakee.colors import Colors
-
+from sakee.stub import KodiStub
+from xbmcgui import ListItem
 
 SORT_METHOD_ALBUM = 14
 SORT_METHOD_ALBUM_IGNORE_THE = 15
@@ -261,10 +260,9 @@ def setResolvedUrl(handle, succeeded, listitem):  # NOSONAR
 
     if succeeded:
         KodiStub.print_line("Item resolved to: {}".format(listitem), color=Colors.Blue)
-        Player.playing_file = listitem.getPath()
+        Player.play(listitem.getPath(), listitem)
     else:
         KodiStub.print_line("Item failed to resolve: {}".format(listitem), color=Colors.Red)
-        Player.playing_file = None
 
 
 # noinspection PyPep8Naming,PyUnusedLocal

--- a/xbmcplugin.py
+++ b/xbmcplugin.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: GPL-3.0
 
 from sakee.colors import Colors
+from sakee.internalplayer import KodiInteralPlayer
 from sakee.stub import KodiStub
 from xbmcgui import ListItem
 
@@ -183,6 +184,9 @@ def endOfDirectory(handle, succeeded=True, updateListing=False, cacheToDisc=True
             updateListing
         ), align_right=True)
 
+    # In case there was something playing force to stop it now.
+    KodiInteralPlayer.instance().stop_playback(force=True)
+
 
 # noinspection PyPep8Naming,PyUnusedLocal
 def addSortMethod(handle, sortMethod, label2Mask="%D"):  # NOSONAR
@@ -256,11 +260,10 @@ def setResolvedUrl(handle, succeeded, listitem):  # NOSONAR
     :param ListItem listitem:   Item the file plugin resolved to for playback.
 
     """
-    from xbmc import Player
 
     if succeeded:
         KodiStub.print_line("Item resolved to: {}".format(listitem), color=Colors.Blue)
-        Player.play(listitem.getPath(), listitem)
+        KodiInteralPlayer.instance().play_resolved_item(listitem.getPath(), listitem)
     else:
         KodiStub.print_line("Item failed to resolve: {}".format(listitem), color=Colors.Red)
 


### PR DESCRIPTION
### Functional description
<!--- Give a clear explanation of the change, fix or new feature 
that this PR contains -->
<!--- Put your text below this line -->
Implements xbmc.Player that emulates the playback of a video.  This is a continuation of #19.
<!--- Put your text above this line -->

### Reasoning
<!--- Provide a decent justification for this PR -->
<!--- Put your text below this line -->
`xmbc.Player` was missing methods.
<!--- Put your text above this line -->

### Technical description
<!--- Please provide a technical analysis of this PR, explaining the 
 changes that were made. -->
<!--- Put your text below this line -->
* Instead of just the `playing_file`, I also keep the current time position and the playback status.
* A thread will be started that will emulate the playing of a file. Events will be emitted from that thread.
* Playback will be stopped when the end of the file has been reached.
* `total_time` is currently hardcoded to `5` seconds. It might make sense to set this value from the info-dict, but that could be empty so we need a hardcoded fallback anyway, unless we want to actually try to load the file and implement a HLS decoder :rocket: 
* I've also added a small test that checks a few methods. I had to include the `tests/home/userdata` folder and an bogus `addon.xml` for `xmbc.py` to properly load.
<!--- Put your text above this line -->
