### PR TITLE
Fixed: get_next_input() would cause an IndexError if no input was present (Fixes #22)

### DIFF
--- a/sakee/stub.py
+++ b/sakee/stub.py
@@ -21,6 +21,9 @@ class KeyboardStub(object):
         self.__queue = []
 
     def get_next_input(self):
+        if len(self.__queue) == 0:
+            return None
+
         return self.__queue.pop(0)
 
     def reset(self):

--- a/tests/test_xbmc.py
+++ b/tests/test_xbmc.py
@@ -1,0 +1,30 @@
+import unittest
+import os
+import xbmc
+
+
+class XbmcTest(unittest.TestCase):
+
+    def test_keyboard_preset_text(self):
+        text = "This is a test"
+        kb = xbmc.Keyboard()
+        stub = kb.get_keyboard_stub()
+        stub.add_input(text)
+        kb.doModal()
+        self.assertTrue(kb.isConfirmed())
+        self.assertEqual(text, kb.getText())
+
+    def test_keyboard_empty(self):
+        kb = xbmc.Keyboard()
+        kb.doModal()
+        self.assertTrue(kb.isConfirmed())
+        self.assertIsNone(kb.getText())
+
+    def test_keyboard_env_var(self):
+        text = "Input set via environment variable"
+        os.environ["KODI_STUB_INPUT"] = text
+        kb = xbmc.Keyboard()
+        kb.get_keyboard_stub().reset()
+        kb.doModal()
+        self.assertTrue(kb.isConfirmed())
+        self.assertEqual(text, kb.getText())


### PR DESCRIPTION

<!--- Give a clear explanation of the change, fix or new feature 
that this PR contains -->
<!--- Put your text below this line -->
Fixes the keyboard IndexError reported in #22
<!--- Put your text above this line -->