### PR TITLE
Run CI tests on windows

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -15,7 +15,18 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ 2.7, 3.7, 3.8 ]
+        os: [ ubuntu-latest ]
+        python-version: [ 2.7, 3.7, 3.8, 3.9 ]
+        include:
+          # Kodi Leia on Windows uses a bundled Python 2.7.
+          - os: windows-latest
+            python-version: 2.7
+
+          # Kodi Matrix on Windows uses a bundled Python 3.8, but we test 3.9 also to be sure.
+          - os: windows-latest
+            python-version: 3.8
+          - os: windows-latest
+            python-version: 3.9
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
### Functional description
* Add Python 3.9 to the list of versions to be tested on linux.
* This adds windows to the CI testing matrix. We will test with Python 2.7 (for Kodi 18), and with Python 3.8 and 3.9 (Kodi 19).
